### PR TITLE
Cleaning up Github actions tasks.

### DIFF
--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -1,29 +1,23 @@
-name: build_master
+name: build Code
 
 on:
   push:
-    tags:
-      - '*'
-  workflow_dispatch:
+    branches:
+      - main
+  pull_request:
+
+
+env:
+  CARGO_TERM_COLOR: always
+
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Run build
       - name: build_script
-        working-directory: /home/runner/work/templatectl/templatectl
-        run: |
-          ./ci_build.sh
-      - name: Upload built binary
-        uses: actions/upload-artifact@v2
-        with:
-          name: templatectl
-          path: target/armv7-unknown-linux-gnueabihf/release/templatectl
-      - name: Release 
-        uses: ncipollo/release-action@v1.12.0
-        with:
-          artifacts: target/armv7-unknown-linux-gnueabihf/release/templatectl
+        run: cargo build 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+# .github/workflows/release.yml
+
+name: Release on templatectl
+
+on: 
+  release:
+    types: [created]
+
+jobs:
+  release:
+    name: release ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64-pc-windows-gnu, x86_64-unknown-linux-musl, x86_64-apple-darwin ]
+    steps:
+      - uses: actions/checkout@master
+      - name: Compile and release
+        uses: rust-build/rust-build.action@v1.4.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPLOAD_MODE: release
+          MINIFY: "yes"
+        with:
+          RUSTTARGET: ${{ matrix.target }}
+          EXTRA_FILES: "README.md LICENSE"


### PR DESCRIPTION
ChangeLog:
  - Adding a job to simply build the project
  - Adding a release tag on create will build a linux,mac,windows artifact and attach it to the release.